### PR TITLE
Replace react native datepicker with community version for RN 0.62

### DIFF
--- a/datepicker.js
+++ b/datepicker.js
@@ -211,11 +211,10 @@ class DatePicker extends Component {
 
     // confirm pressed
     const timePickerVisible = androidDatePickerMode === DATE_MODE && mode === DATETIME_MODE;
-    const _date = Moment(date).toDate();
-    const _androideDatePickerMode = timePickerVisible ? TIME_MODE : undefined;
+    const _androidDatePickerMode = timePickerVisible ? TIME_MODE : undefined;
     this.setState({
-      androidDatePickerMode: _androideDatePickerMode,
-      date: _date
+      androidDatePickerMode: _androidDatePickerMode,
+      date: Moment(date).toDate()
     });
 
     if (!timePickerVisible) {

--- a/datepicker.js
+++ b/datepicker.js
@@ -239,11 +239,11 @@ class DatePicker extends Component {
       this.setModalVisible(true);
     } else {
       const {mode} = this.props;
-      // 选日期
+      // Choose date
       if (mode === DATE_MODE || mode === DATETIME_MODE) {
         this.setState({androidDatePickerMode: DATE_MODE});
       } else if (mode === TIME_MODE) {
-        // 选时间
+        // Choose time
         this.setState({androidDatePickerMode: TIME_MODE});
       }
     }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "react-native": "0.49.3",
     "react-test-renderer": "16.0.0-beta.5"
   },
+  "peerDependencies": {
+    "@react-native-community/datetimepicker": "3.0.3"
+  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"


### PR DESCRIPTION
used this one --> https://github.com/xgfe/react-native-datepicker/pull/436/files

another one that tries to do the upgrade --> https://github.com/xgfe/react-native-datepicker/pull/429/files

Migration to @react-native-community/datetimepicker: https://github.com/react-native-datetimepicker/datetimepicker#migration-from-the-older-components